### PR TITLE
fixup! simplify params

### DIFF
--- a/geometry/render/dev/render_gltf_client/test/run_simulation_and_render.cc
+++ b/geometry/render/dev/render_gltf_client/test/run_simulation_and_render.cc
@@ -23,6 +23,8 @@
 #include "drake/systems/sensors/pixel_types.h"
 #include "drake/systems/sensors/rgbd_sensor.h"
 
+using drake::geometry::RenderEngineGltfClientParams;
+
 DEFINE_double(simulation_time, 10.0,
               "Desired duration of the simulation in seconds.");
 DEFINE_bool(render_on, true, "Sets rendering generally enabled (or not)");
@@ -45,6 +47,12 @@ DEFINE_string(camera_xyz_rpy, "0.8, 0.0, 0.5, -2.2, 0.0, 1.57",
 DEFINE_string(
     save_dir, "",
     "If specified, the rendered images will be saved to this directory.");
+DEFINE_string(
+    server_base_url, RenderEngineGltfClientParams{}.base_url,
+    "The base_url for the render server.");
+DEFINE_string(
+    server_render_endpoint, RenderEngineGltfClientParams{}.render_endpoint,
+    "The render_endpoint for the render server.");
 
 static bool valid_render_engine(const char* flagname, const std::string& val) {
   if (val == "vtk")
@@ -284,9 +292,11 @@ int do_main() {
     scene_graph->AddRenderer(render_name,
                              geometry::MakeRenderEngineVtk({}));
   } else {  // FLAGS_render_engine == "client"
+    RenderEngineGltfClientParams params;
+    params.base_url = FLAGS_server_base_url;
+    params.render_endpoint = FLAGS_server_render_endpoint;
     scene_graph->AddRenderer(render_name,
-                             geometry::MakeRenderEngineGltfClient(
-                                 geometry::RenderEngineGltfClientParams()));
+                             geometry::MakeRenderEngineGltfClient(params));
   }
 
   AddShapes(scene_graph);

--- a/geometry/render_gltf_client/BUILD.bazel
+++ b/geometry/render_gltf_client/BUILD.bazel
@@ -68,7 +68,6 @@ drake_cc_googletest(
     name = "render_engine_gltf_client_params_test",
     deps = [
         ":render_engine_gltf_client_params",
-        "//common/test_utilities:expect_throws_message",
     ],
 )
 

--- a/geometry/render_gltf_client/render_engine_gltf_client_params.cc
+++ b/geometry/render_gltf_client/render_engine_gltf_client_params.cc
@@ -8,31 +8,12 @@ namespace geometry {
 std::string RenderEngineGltfClientParams::GetUrl() const {
   std::string url = base_url;
   std::string endpoint = render_endpoint;
-
-  const std::string throw_message =
-      "RenderEngineGltfClientParams: invalid base_url or render_endpoint is "
-      "provided that contains only `/`.";
-
-  auto all_slashes = [](const std::string& str) {
-    if (str.empty()) return false;
-    return std::all_of(str.begin(), str.end(), [](char c){ return c == '/'; });
-  };
-
-  if (!all_slashes(url)) {
-    while (url.size() > 0 && url.back() == '/') url.pop_back();
-  } else {
-    throw std::logic_error(throw_message);
+  while (url.size() > 0 && url.back() == '/') {
+    url.pop_back();
   }
-
-  if (endpoint == "/") {
-    // Return the full URL as ``url`/` in this case.
-    endpoint = "";
-  } else if (!all_slashes(endpoint)) {
-    while (endpoint.size() > 0 && endpoint.front() == '/') endpoint.erase(0, 1);
-  } else {
-    throw std::logic_error(throw_message);
+  while (endpoint.size() > 0 && endpoint.front() == '/') {
+    endpoint.erase(0, 1);
   }
-
   return url + "/" + endpoint;
 }
 

--- a/geometry/render_gltf_client/render_engine_gltf_client_params.h
+++ b/geometry/render_gltf_client/render_engine_gltf_client_params.h
@@ -11,8 +11,8 @@ namespace geometry {
 /** Construction parameters for the MakeRenderEngineGltfClient() to create a
  client as part of the @ref render_engine_gltf_client_server_api. */
 struct RenderEngineGltfClientParams {
-  /** The base url of the server communicate with.  Any trailing slashes will be
-   pruned when querying the full url from GetUrl() method. */
+  /** The base url of the server communicate with.
+  See GetUrl() for details.*/
   std::string base_url{"http://127.0.0.1"};
 
   /** The port to communicate on.  A value less than or equal to `0` will let
@@ -20,10 +20,8 @@ struct RenderEngineGltfClientParams {
    instead, specify `port` to override that. */
   int port{8000};
 
-  /** (Advanced) The server endpoint to retrieve renderings from.  Any leading
-   slashes will be pruned when querying the full url from GetUrl() method.
-   Trailing slashes, however, will be kept as-is.  If the server expects forms
-   posted to `/` then this value should be the empty string. */
+  /** (Advanced) The server endpoint to retrieve renderings from.
+  See GetUrl() for details.*/
   std::string render_endpoint{"render"};
 
   /** The (optional) label to apply when none is otherwise specified.  */
@@ -50,11 +48,9 @@ struct RenderEngineGltfClientParams {
   bool no_cleanup = false;
 
   /** Returns the post-processed full URL used for client-server communication.
-   The full url is constructed as `{url}/{endpoint}` where any trailing slashes
-   in `base_url` and any leading slashes in `render_endpoint` are removed.
-
-   Throws an exception if either `base_url` or `render_endpoint` becomes the
-   empty string after slash pruning. */
+   The full url is constructed as `{base_url}/{render_endpoint}` where all
+   trailing slashes in `base_url` and all leading slashes in `render_endpoint`
+   have been removed. */
   std::string GetUrl() const;
 };
 


### PR DESCRIPTION
The Params class doesn't need to validate the input.  The best way to see if a URL is valid is to POST to it, which the RenderClient already does within the couple seconds of operation.

I think its extremely unlikely that a user would ever pass an empty base_url.  But even if they do, they still get a nice exception message with the details (from render client) -- it just takes a couple of seconds to see it (after the curl fails).